### PR TITLE
add update step for playwright system deps

### DIFF
--- a/bin/update.py
+++ b/bin/update.py
@@ -93,6 +93,10 @@ def main() -> None:
     print('* Install or make sure the playwright browsers are installed.')
     keep_going(args.yes)
     run_command('poetry run playwright install')
+    
+    print('* Install the necessary system dependendencies for playwright')
+    keep_going(args.yes)
+    run_command('poetry run playwright install-deps') 
 
     print('* Validate configuration files.')
     keep_going(args.yes)


### PR DESCRIPTION
## Type of change

**Description:**

The update process didn't include a step to update system dependencies for playwright. This caused errors when updating Lookyloo/playwright, without updating/installing the new dependencies. 

![image](https://github.com/user-attachments/assets/73afbc51-e7c0-4e20-b5bf-f2c91f76a9cd)


**Select the type of change(s) made in this pull request:**
- [x] Bug fix *(non-breaking change which fixes an issue)*
- [x] New feature *(non-breaking change which adds functionality)*
- [ ] Documentation *(change or fix to documentation)*

---------------------------------------------------------------------------------------------------------

## Proposed changes <!-- Describe the changes the PR makes. -->

* add an extra step in the update.py process that runs `playwright install-deps`
