### PR TITLE
fix: Pass send_mail() arguments by keyword in /report API endpoint

### DIFF
--- a/website/web/genericapi.py
+++ b/website/web/genericapi.py
@@ -8,6 +8,7 @@ import gzip
 import hashlib
 import ipaddress
 import json
+import re
 
 from datetime import datetime
 from io import BytesIO
@@ -35,6 +36,11 @@ api = Namespace('GenericAPI', description='Generic Lookyloo API', path='/')
 
 lookyloo: Lookyloo = get_lookyloo_instance()
 comparator: Comparator = Comparator()
+
+# Standard HTML5 email validation pattern (same as the WHATWG <input type="email"> spec).
+# \A and \Z anchors (rather than ^/$) reject any embedded or trailing newline, blocking
+# Reply-To header injection.
+EMAIL_RE = re.compile(r"\A[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\Z")
 
 
 def api_auth_check(method):  # type: ignore[no-untyped-def]
@@ -710,7 +716,14 @@ class CaptureReport(Resource):  # type: ignore[misc]
     @api.param('comment', 'Description of the URL, will be given to the analyst.')  # type: ignore[untyped-decorator]
     def post(self, capture_uuid: str) -> Response:
         parameters: dict[str, Any] = request.get_json(force=True)
-        mail_sent = lookyloo.send_mail(capture_uuid, parameters.get('email', ''), parameters.get('comment'))
+        email: str = parameters['email'] if parameters.get('email') else ''
+        if not EMAIL_RE.match(email):
+            # skip clearly incorrect emails (also avoids Reply-To header injection)
+            email = ''
+        mail_sent = lookyloo.send_mail(capture_uuid,
+                                       as_admin=flask_login.current_user.is_authenticated,
+                                       email=email,
+                                       comment=parameters.get('comment'))
         if isinstance(mail_sent, bool):
             # Success
             mail_sent = {'info': 'Report sent succesfully'}


### PR DESCRIPTION
## Type of change

**Description:**
Fixes a positional argument bug by using named arguments and adding validation to the `send_mail() `.

**Select the type of change(s) made in this pull request:**
- [x] Bug fix *(non-breaking change which fixes an issue)*
- [ ] New feature *(non-breaking change which adds functionality)*
- [ ] Documentation *(change or fix to documentation)*

---------------------------------------------------------------------------------------------------------

## Proposed changes <!-- Describe the changes the PR makes. -->

CaptureReport.post called lookyloo.send_mail() with positional arguments, but send_mail's first parameter after the positional-only capture_uuid is `as_admin`, not `email`. The reporter-supplied `email` value was therefore bound to `as_admin` (any non-empty string is truthy), causing admin-scoped MISP lookups for any caller, and the `comment` value was bound to `email` and used unvalidated as the Reply-To header.

Call send_mail() with keyword arguments so each value lands in the correct parameter and `as_admin` reflects the actual authentication state (False for unauthenticated callers). Also validate the reporter email against a standard pattern before use, mirroring the /tree/<uuid>/send_mail web route; the regex is anchored with \A/\Z so an embedded or trailing newline cannot be smuggled into the Reply-To header.
